### PR TITLE
Increase the timeout for mocked http calls in the unit tests

### DIFF
--- a/src/test/kotlin/com/philips/hsdp/apis/iam/oauth2/IamOAuth2Test.kt
+++ b/src/test/kotlin/com/philips/hsdp/apis/iam/oauth2/IamOAuth2Test.kt
@@ -53,7 +53,7 @@ class IamOAuth2Test {
             start()
         }
         private val tokenRefresherMock = mockk<TokenRefresher>()
-        val httpClient = HttpClient(callTimeout = Duration.ofMillis(200)).apply {
+        val httpClient = HttpClient(callTimeout = Duration.ofMillis(300)).apply {
             tokenRefresher = tokenRefresherMock
         }
         private val initialToken = Token(

--- a/src/test/kotlin/com/philips/hsdp/apis/iam/user/IamUserTestBase.kt
+++ b/src/test/kotlin/com/philips/hsdp/apis/iam/user/IamUserTestBase.kt
@@ -36,7 +36,7 @@ open class IamUserTestBase {
     private val tokenRefresherMock = mockk<TokenRefresher>().apply {
         every { token } returns Token(accessToken = "22a34a6e-214c-4e3e-b85f-b4bbd1448613")
     }
-    val httpClient = HttpClient(callTimeout = Duration.ofMillis(200)).apply {
+    val httpClient = HttpClient(callTimeout = Duration.ofMillis(300)).apply {
         tokenRefresher = tokenRefresherMock
     }
     protected val iamUser = IamUser(

--- a/src/test/kotlin/com/philips/hsdp/apis/provisioning/ProvisioningServiceTest.kt
+++ b/src/test/kotlin/com/philips/hsdp/apis/provisioning/ProvisioningServiceTest.kt
@@ -43,7 +43,7 @@ internal class ProvisioningServiceTest {
         start()
     }
     private val tokenRefresherMock = mockk<TokenRefresher>()
-    val httpClient = HttpClient(callTimeout = Duration.ofMillis(200)).apply {
+    val httpClient = HttpClient(callTimeout = Duration.ofMillis(300)).apply {
         tokenRefresher = tokenRefresherMock
     }
     private val provisioningService = ProvisioningService(server.url("").toString(), httpClient)

--- a/src/test/kotlin/com/philips/hsdp/apis/tdr/TDRTest.kt
+++ b/src/test/kotlin/com/philips/hsdp/apis/tdr/TDRTest.kt
@@ -50,7 +50,7 @@ internal class TDRTest {
         start()
     }
     private val tokenRefresherMock = mockk<TokenRefresher>()
-    val httpClient = HttpClient(callTimeout = Duration.ofMillis(200)).apply {
+    val httpClient = HttpClient(callTimeout = Duration.ofMillis(300)).apply {
         tokenRefresher = tokenRefresherMock
     }
     private val tdr = TDR(server.url("").toString(), httpClient)


### PR DESCRIPTION
Prevent that the unit tests unnecessarily fail in CI/CD.