### PR TITLE
feat: Small extensions to the CDR APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,6 @@ The current implementation covers only a subset of HSDP APIs. Additional functio
   - [ ] Get History
   - [ ] Batch operation
   - [ ] Get Capabilities
-  - [ ] Pagination
 - [x] Telemetry Data Repository (TDR)
   - [x] Contracts
   - [x] Data Items

--- a/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/CreateRequest.kt
+++ b/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/CreateRequest.kt
@@ -24,13 +24,19 @@ data class CreateRequest(
     val body: String,
 
     /**
+     * If set to false, the resource validation against the base StructureDefinition
+     * and any profiles declared in meta.profile is skipped. Default value is true.
+     */
+    val validate: Boolean? = null,
+
+    /**
      * Optional parameter to choose the response MIME type for clients that cannot modify the Accept_header.
      * Overrides the value given in the 'Accept' header.
      */
     val format: FormatParameter? = null,
 
     /**
-     * Condition that must be satisfied to create the resource.
+     * Indicates that the resource is only created if the condition specified in this header is not met.
      * If defined, will lead to an 'If-None-Exists' header with given expression.
      */
     val condition: String? = null,

--- a/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/PatchByIdRequest.kt
+++ b/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/PatchByIdRequest.kt
@@ -40,6 +40,12 @@ data class PatchByIdRequest(
     val forVersion: String? = null,
 
     /**
+     * If set to true, the resource is validated against the base StructureDefinition
+     * and any profiles declared in meta.profile
+     */
+    val validate: Boolean? = null,
+
+    /**
      * Optional parameter to choose the response MIME type for clients that cannot modify the 'Accept' header.
      * Overrides the value given in the 'Accept' header.
      */

--- a/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/ReadRequest.kt
+++ b/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/ReadRequest.kt
@@ -24,6 +24,16 @@ data class ReadRequest(
     val id: String,
 
     /**
+     * Indicates that a resource be returned only if modified from the given date/time.
+     */
+    val modifiedSinceTimestamp: String? = null,
+
+    /**
+     * Indicate that a resource be returned only if the resource had undergone changes since the given versionId.
+     */
+    val modifiedSinceVersion: String? = null,
+
+    /**
      * Optional parameter to choose the response MIME type for clients that cannot modify the 'Accept' header.
      * Overrides the value given in the 'Accept' header.
      */

--- a/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/UpdateByIdRequest.kt
+++ b/src/main/kotlin/com/philips/hsdp/apis/cdr/domain/sdk/UpdateByIdRequest.kt
@@ -35,6 +35,12 @@ data class UpdateByIdRequest(
     val forVersion: String? = null,
 
     /**
+     * If set to true, the resource is validated against the base StructureDefinition
+     * and any profiles declared in meta.profile
+     */
+    val validate: Boolean? = null,
+
+    /**
      * Optional parameter to choose the response MIME type for clients that cannot modify the 'Accept' header.
      * Overrides the value given in the 'Accept' header.
      */

--- a/src/test/kotlin/com/philips/hsdp/apis/cdr/CreateTest.kt
+++ b/src/test/kotlin/com/philips/hsdp/apis/cdr/CreateTest.kt
@@ -57,6 +57,26 @@ internal class CreateTest : CdrTestBase() {
     }
 
     @TestFactory
+    fun `Validate value - if set - should be propagated to headers`() = listOf(
+        false to "false",
+        true to "true",
+    ).map { (validate, expectedHeaderValue) ->
+        DynamicTest.dynamicTest("Value $validate should lead to header parameter $expectedHeaderValue") {
+            runBlocking {
+                // Given
+                server.enqueue(mockSuccessResponse)
+
+                // When
+                cdr.create(basicRequest.copy(validate = validate))
+
+                // Then
+                val request = server.takeRequest()
+                request.headers["X-validate-resource"] shouldBe expectedHeaderValue
+            }
+        }
+    }
+
+    @TestFactory
     fun `FormatParameter value should be propagated to query parameters`() = listOf(
         FormatParameter.Json to "_format=json",
         FormatParameter.ApplicationJson to "_format=application%2Fjson",

--- a/src/test/kotlin/com/philips/hsdp/apis/cdr/PatchByIdTest.kt
+++ b/src/test/kotlin/com/philips/hsdp/apis/cdr/PatchByIdTest.kt
@@ -76,6 +76,26 @@ internal class PatchByIdTest : CdrTestBase() {
         }
     }
 
+    @TestFactory
+    fun `Validate value - if set - should be propagated to headers`() = listOf(
+        false to "false",
+        true to "true",
+    ).map { (validate, expectedHeaderValue) ->
+        DynamicTest.dynamicTest("Value $validate should lead to header parameter $expectedHeaderValue") {
+            runBlocking {
+                // Given
+                server.enqueue(mockSuccessResponse)
+
+                // When
+                cdr.patch(basicRequest.copy(validate = validate))
+
+                // Then
+                val request = server.takeRequest()
+                request.headers["X-validate-resource"] shouldBe expectedHeaderValue
+            }
+        }
+    }
+
     @Test
     fun `ForVersion value should be propagated to the request headers`(): Unit = runBlocking {
         // Given

--- a/src/test/kotlin/com/philips/hsdp/apis/cdr/UpdateByIdTest.kt
+++ b/src/test/kotlin/com/philips/hsdp/apis/cdr/UpdateByIdTest.kt
@@ -74,6 +74,26 @@ internal class UpdateByIdTest : CdrTestBase() {
         result shouldBe UpdateResponse(200, """{"key":"value"}""", "location", "abc", "2021-09-21T17:11:39Z")
     }
 
+    @TestFactory
+    fun `Validate value - if set - should be propagated to headers`() = listOf(
+        false to "false",
+        true to "true",
+    ).map { (validate, expectedHeaderValue) ->
+        DynamicTest.dynamicTest("Value $validate should lead to header parameter $expectedHeaderValue") {
+            runBlocking {
+                // Given
+                server.enqueue(mockSuccessResponse)
+
+                // When
+                cdr.update(basicRequest.copy(validate = validate))
+
+                // Then
+                val request = server.takeRequest()
+                request.headers["X-validate-resource"] shouldBe expectedHeaderValue
+            }
+        }
+    }
+
     @Test
     fun `ForVersion value should be propagated to the request headers`(): Unit = runBlocking {
         // Given


### PR DESCRIPTION
- extend create, update and patch with the option to validate the resource.
- extend read with the options to only return the item if it is modified after a given timestamp or version id.