### PR TITLE
Make callTimeout leading and set the other timeouts to the same value…

### DIFF
--- a/src/main/kotlin/com/philips/hsdp/apis/support/HttpClient.kt
+++ b/src/main/kotlin/com/philips/hsdp/apis/support/HttpClient.kt
@@ -41,6 +41,9 @@ class HttpClient(callTimeout: Duration = Duration.ofSeconds(5)) : Authenticator 
     val client = OkHttpClient().newBuilder()
         .authenticator(this)
         .callTimeout(callTimeout)
+        .readTimeout(callTimeout)
+        .writeTimeout(callTimeout)
+        .connectTimeout(callTimeout)
         .build()
 
     /**


### PR DESCRIPTION
… so that the callTimeout is always respected