### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: '11.0.1'
           distribution: 'zulu'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-    kotlin("jvm") version "1.6.10"
-    kotlin("plugin.serialization") version "1.6.10"
-    kotlin("kapt") version "1.6.10"
-    id("org.jetbrains.kotlinx.kover") version "0.4.4"
-    id("org.jetbrains.dokka") version "1.6.10"
+    kotlin("jvm") version "1.6.21"
+    kotlin("plugin.serialization") version "1.6.21"
+    kotlin("kapt") version "1.6.21"
+    id("org.jetbrains.kotlinx.kover") version "0.5.0"
+    id("org.jetbrains.dokka") version "1.6.21"
     id("org.sonarqube") version "3.3"
     jacoco
     id("com.github.hierynomus.license") version "0.16.1"
@@ -16,8 +16,8 @@ repositories {
 }
 
 val okHttpVersion = "4.9.3"
-val kotestVersion = "5.1.0"
-val coroutineVersion = "1.6.0-native-mt"
+val kotestVersion = "5.2.3"
+val coroutineVersion = "1.6.1-native-mt"
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions {
@@ -57,7 +57,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-json:$kotestVersion")
-    testImplementation("io.mockk:mockk:1.12.2")
+    testImplementation("io.mockk:mockk:1.12.3")
     testImplementation("com.squareup.okhttp3:mockwebserver:$okHttpVersion")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.philips.hsdp.apis
 kotlin.code.style = official
-version = 0.5.0-SNAPSHOT
+version = 0.4.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.philips.hsdp.apis
 kotlin.code.style = official
-version = 0.4.2-SNAPSHOT
+version = 0.4.2


### PR DESCRIPTION
Combine various dependabot pull requests into one
- Bump kapt from 1.6.10 to 1.6.21
- Bump jvm from 1.6.10 to 1.6.21
- Bump kotestVersion from 5.1.0 to 5.2.2
- Bump mockk from 1.12.2 to 1.12.3
- Bump org.jetbrains.kotlinx.kover from 0.4.4 to 0.5.0
- Bump actions/checkout from 2 to 3
- Bump actions/setup-java from 2 to 3  dependencies github_actions